### PR TITLE
Loop (don't merge this! just for discussion)

### DIFF
--- a/src/Cell.purs
+++ b/src/Cell.purs
@@ -15,7 +15,9 @@ import SodiumFRP.Class(
     CellLoop,
     toCell,
     class SodiumCell,
-    Stream
+    Stream,
+    class Loop,
+    newCellLoop
 )
 
 import Prelude
@@ -23,15 +25,16 @@ import Effect (Effect)
 import Effect.Uncurried (EffectFn2, runEffectFn2)
 import Data.Function.Uncurried (
     Fn1, runFn1,
-    Fn2, mkFn2, 
-    Fn3, runFn3, mkFn3, 
-    Fn4, runFn4, mkFn4, 
+    Fn2, mkFn2,
+    Fn3, runFn3, mkFn3,
+    Fn4, runFn4, mkFn4,
     Fn5, runFn5, mkFn5,
     Fn6, runFn6, mkFn6,
     Fn7, runFn7
 )
+import Data.Tuple
 
--- | Sample 
+-- | Sample
 
 sample :: forall a c. (SodiumCell c) => c a -> a
 sample c = runFn1 sampleImpl (toCell c)
@@ -40,9 +43,9 @@ foreign import sampleImpl :: forall a. Fn1 (Cell a) (a)
 
 {-| Loop
 
-    Resolve the loop to specify what the CellLoop was a forward reference to. 
+    Resolve the loop to specify what the CellLoop was a forward reference to.
     It must be invoked inside the same transaction as the place where the CellLoop is used.
-    This requires you to create an explicit transaction 
+    This requires you to create an explicit transaction
 -}
 loopCell :: forall a c. (SodiumCell c) => c a -> CellLoop a -> Effect Unit
 loopCell c = runEffectFn2 loopCellImpl (toCell c)
@@ -55,7 +58,7 @@ foreign import loopCellImpl :: forall a. EffectFn2 (Cell a) (CellLoop a) Unit
 
 lift :: forall a b c cel. (SodiumCell cel) => (a -> b -> c) -> cel b -> cel a -> Cell c
 lift f c1 c2 = runFn3 liftImpl (mkFn2 f) (toCell c1) (toCell c2)
-         
+
 lift3 :: forall a b c d cel. (SodiumCell cel) => (a -> b -> c -> d) -> cel b -> cel c -> cel a -> Cell d
 lift3 f c1 c2 c3 = runFn4 lift3Impl (mkFn3 f) (toCell c1) (toCell c2) (toCell c3)
 
@@ -79,11 +82,10 @@ foreign import lift6Impl :: forall a b c d e f g. Fn7 (Fn6 a b c d e f g) (Cell 
 -}
 
 switchC :: forall a c. (SodiumCell c) => c (Cell a) -> Cell a
-switchC c = runFn1 switchCImpl (toCell c) 
+switchC c = runFn1 switchCImpl (toCell c)
 
 switchS :: forall a c. (SodiumCell c) => c (Stream a) -> Stream a
-switchS c = runFn1 switchSImpl (toCell c) 
+switchS c = runFn1 switchSImpl (toCell c)
 
 foreign import switchCImpl :: forall a. Fn1 (Cell (Cell a)) (Cell a)
 foreign import switchSImpl :: forall a. Fn1 (Cell (Stream a)) (Stream a)
-

--- a/src/Class.js
+++ b/src/Class.js
@@ -8,6 +8,18 @@ const Stream = Sodium.Stream;
 const StreamSink = Sodium.StreamSink;
 const StreamLoop = Sodium.StreamLoop;
 
+exports.loopCellImpl_ = function(c, cLoop) {
+    cLoop.loop(c);
+}
+
+exports.loopStreamImpl_ = function(s, sLoop) {
+    sLoop.loop(s);
+}
+
+exports.runTransactionImpl_ = function(fn) {
+    return Sodium.Transaction.run(fn);
+}
+
 // Constructors
 
 exports.newStreamImpl = function() {

--- a/test/Transaction.test.purs
+++ b/test/Transaction.test.purs
@@ -3,9 +3,9 @@ module Test.Transaction (testTransaction) where
 import Prelude
 
 import SodiumFRP.Transaction (runTransaction)
-import SodiumFRP.Class (newCellLoop, newCell, newStream, newStreamLoop)
+import SodiumFRP.Class (newCellLoop, newCell, newStream, newStreamLoop, loop2)
 import SodiumFRP.Cell (loopCell, sample)
-import SodiumFRP.Stream (loopStream) 
+import SodiumFRP.Stream (loopStream)
 import Effect (Effect)
 import Effect.Class (liftEffect)
 import Test.Unit (suite, test)
@@ -21,20 +21,31 @@ testTransaction = runTest do
             )
             Assert.equal result 2
 
+        test "cell stream loop" do
+            result <- liftEffect $ do
+                cc <- loop2 (\ret ca' cb' -> do
+                    let cc = (_ * 2) <$> cb'
+                    let cb = (_ * 2) <$> ca'
+                    let ca = newCell 2
+                    pure $ ret ca cb cc
+                )
+                pure $ sample cc
+            Assert.equal result 8
+
         test "cell loop in transaction" do
             result <- liftEffect $ runTransaction (do
                 l <- newCellLoop
                 let c = newCell 2
                 loopCell c l
-                pure $ sample l 
+                pure $ sample l
             )
             Assert.equal result 2
-        
+
         test "stream loop in transaction" do
             result <- liftEffect $ runTransaction (do
                 l <- newStreamLoop
-                let s = newStream 
+                let s = newStream
                 loopStream s l
-                pure unit 
+                pure unit
             )
             pure unit


### PR DESCRIPTION
This style of loop does not need to be performed within a Transaction, it can save us on coming up with a specialized monad to force looping to only happen in a transaction.

An example usage:
```
                cc <- loop2 (\ret ca' cb' -> do
                    let cc = (_ * 2) <$> cb'
                    let cb = (_ * 2) <$> ca'
                    let ca = newCell 2
                    pure $ ret ca cb cc
                )
```
Cells and Streams can be mixed in the parameters, they do not need to be of the same sodium object type.
```loop1```, ```loop2```, and ```loop3``` are defined from ```loop``` and we can go as big as we want.

However the type signature is a bit complicated:
```loop2 :: forall a b c target1 target2. Loop target1 => Loop target2 => (forall r. (target1 a -> target2 b -> c -> r) -> target1 a -> target2 b -> Effect r) -> Effect c```

Just an idea anyway. Do not merge this yet, it is just for discussion. (And its just a quick hack, code is a mess)

Also ```Cell``` / ```CellStream``` / ```CellLoop``` should probably be defined in ```Cell.purs```, and just keep the typeclasses in ```Class.purs```. Otherwise it is impossible to implement ```Loop``` for ```Cell```. Likewise for Streams. (Cyclic module dependencies and orphan instances)