### PR TITLE
Function args

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -38,12 +38,12 @@
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "inflight": {
@@ -52,8 +52,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -68,7 +68,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "once": {
@@ -77,7 +77,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "path-is-absolute": {
@@ -92,7 +92,7 @@
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
-        "glob": "7.1.2"
+        "glob": "^7.0.5"
       }
     },
     "sanctuary-type-classes": {
@@ -101,7 +101,7 @@
       "integrity": "sha512-rFW27f3D622kxKravpGU9OjWn66fnDjDjGPvoYo4hEoBg2ocypvp0R9cs0YovKL3jTO+PTceUBh5tYZ+l9ay3g==",
       "dev": true,
       "requires": {
-        "sanctuary-type-identifiers": "1.0.0"
+        "sanctuary-type-identifiers": "1.0.x"
       }
     },
     "sanctuary-type-identifiers": {
@@ -116,8 +116,8 @@
       "integrity": "sha512-8TJ8ZMZJIPRp2kapKuuEmr3wpMr2dvw3sO/r/F2e8GagdwA3f4U41z3183d8dJlwADNERH7K3LzNPm1YzdbMbg==",
       "dev": true,
       "requires": {
-        "sanctuary-type-classes": "9.0.0",
-        "typescript-collections": "1.3.2"
+        "sanctuary-type-classes": "^9.0.0",
+        "typescript-collections": "^1.3.2"
       }
     },
     "typescript-collections": {

--- a/src/Cell.js
+++ b/src/Cell.js
@@ -6,7 +6,7 @@ exports.sampleImpl = function(c) {
     return c.sample();
 }
 
-exports.loopCellImpl = function(c, cLoop) {
+exports.loopCellImpl = function(cLoop, c) {
     cLoop.loop(c);
 }
 

--- a/src/Cell.js
+++ b/src/Cell.js
@@ -10,20 +10,20 @@ exports.loopCellImpl = function(c, cLoop) {
     cLoop.loop(c);
 }
 
-exports.liftImpl = function (fn, c1, c) {
+exports.liftImpl = function (fn, c, c1) {
     return c.lift(c1, fn);
 }
 
-exports.lift3Impl = function (fn, c1, c2, c) {
+exports.lift3Impl = function (fn, c, c1, c2) {
     return c.lift3(c1, c2, fn);
 }
-exports.lift4Impl = function (fn, c1, c2, c3, c) {
+exports.lift4Impl = function (fn, c, c1, c2, c3) {
     return c.lift4(c1, c2, c3, fn);
 }
-exports.lift5Impl = function (fn, c1, c2, c3, c4, c) {
+exports.lift5Impl = function (fn, c, c1, c2, c3, c4) {
     return c.lift5(c1, c2, c3, c4, fn);
 }
-exports.lift6Impl = function (fn, c1, c2, c3, c4, c5, c) {
+exports.lift6Impl = function (fn, c, c1, c2, c3, c4, c5) {
     return c.lift6(c1, c2, c3, c4, c5, fn);
 }
 

--- a/src/Cell.purs
+++ b/src/Cell.purs
@@ -41,10 +41,10 @@ foreign import sampleImpl :: forall a. EffectFn1 (Cell a) (a)
 -- | Resolve the loop to specify what the CellLoop was a forward reference to. 
 -- | It must be invoked inside the same transaction as the place where the CellLoop is used.
 -- | This requires you to create an explicit transaction 
-loopCell :: forall a c. (SodiumCell c) => c a -> CellLoop a -> Effect Unit
-loopCell c = runEffectFn2 loopCellImpl (toCell c)
+loopCell :: forall a c. (SodiumCell c) => CellLoop a -> c a -> Effect Unit
+loopCell loopTarget c = runEffectFn2 loopCellImpl loopTarget (toCell c)
 
-foreign import loopCellImpl :: forall a. EffectFn2 (Cell a) (CellLoop a) Unit
+foreign import loopCellImpl :: forall a. EffectFn2 (CellLoop a) (Cell a) Unit
 
 -- Lift
 lift :: forall a b c cel. (SodiumCell cel) => (a -> b -> c) -> cel a -> cel b -> Cell c

--- a/src/Cell.purs
+++ b/src/Cell.purs
@@ -47,26 +47,26 @@ loopCell c = runEffectFn2 loopCellImpl (toCell c)
 foreign import loopCellImpl :: forall a. EffectFn2 (Cell a) (CellLoop a) Unit
 
 -- Lift
-lift :: forall a b c cel. (SodiumCell cel) => (a -> b -> c) -> cel b -> cel a -> Cell c
+lift :: forall a b c cel. (SodiumCell cel) => (a -> b -> c) -> cel a -> cel b -> Cell c
 lift f c1 c2 = runFn3 liftImpl (mkFn2 f) (toCell c1) (toCell c2)
          
-lift3 :: forall a b c d cel. (SodiumCell cel) => (a -> b -> c -> d) -> cel b -> cel c -> cel a -> Cell d
+lift3 :: forall a b c d cel. (SodiumCell cel) => (a -> b -> c -> d) -> cel a -> cel b -> cel c -> Cell d
 lift3 f c1 c2 c3 = runFn4 lift3Impl (mkFn3 f) (toCell c1) (toCell c2) (toCell c3)
 
-lift4 :: forall a b c d e cel. (SodiumCell cel) => (a -> b -> c -> d -> e) -> cel b -> cel c -> cel d -> cel a -> Cell e
+lift4 :: forall a b c d e cel. (SodiumCell cel) => (a -> b -> c -> d -> e) -> cel a -> cel b -> cel c -> cel d -> Cell e
 lift4 f c1 c2 c3 c4 = runFn5 lift4Impl (mkFn4 f) (toCell c1) (toCell c2) (toCell c3) (toCell c4)
 
-lift5 :: forall a b c d e f cel. (SodiumCell cel) => (a -> b -> c -> d -> e -> f) -> cel b -> cel c -> cel d -> cel e -> cel a -> Cell f
+lift5 :: forall a b c d e f cel. (SodiumCell cel) => (a -> b -> c -> d -> e -> f) -> cel a -> cel b -> cel c -> cel d -> cel e -> Cell f
 lift5 f c1 c2 c3 c4 c5 = runFn6 lift5Impl (mkFn5 f) (toCell c1) (toCell c2) (toCell c3) (toCell c4) (toCell c5)
 
-lift6 :: forall a b c d e f g cel. (SodiumCell cel) => (a -> b -> c -> d -> e -> f -> g) -> cel b -> cel c -> cel d -> cel e -> cel f -> cel a -> Cell g
+lift6 :: forall a b c d e f g cel. (SodiumCell cel) => (a -> b -> c -> d -> e -> f -> g) -> cel a -> cel b -> cel c -> cel d -> cel e -> cel f -> Cell g
 lift6 f c1 c2 c3 c4 c5 c6 = runFn7 lift6Impl (mkFn6 f) (toCell c1) (toCell c2) (toCell c3) (toCell c4) (toCell c5) (toCell c6)
 
-foreign import liftImpl :: forall a b c. Fn3 (Fn2 a b c) (Cell b) (Cell a) (Cell c)
-foreign import lift3Impl :: forall a b c d. Fn4 (Fn3 a b c d) (Cell b) (Cell c) (Cell a) (Cell d)
-foreign import lift4Impl :: forall a b c d e. Fn5 (Fn4 a b c d e) (Cell b) (Cell c) (Cell d) (Cell a) (Cell e)
-foreign import lift5Impl :: forall a b c d e f. Fn6 (Fn5 a b c d e f) (Cell b) (Cell c) (Cell d) (Cell e) (Cell a) (Cell f)
-foreign import lift6Impl :: forall a b c d e f g. Fn7 (Fn6 a b c d e f g) (Cell b) (Cell c) (Cell d) (Cell e) (Cell f) (Cell a) (Cell g)
+foreign import liftImpl :: forall a b c. Fn3 (Fn2 a b c) (Cell a) (Cell b) (Cell c)
+foreign import lift3Impl :: forall a b c d. Fn4 (Fn3 a b c d) (Cell a) (Cell b) (Cell c) (Cell d)
+foreign import lift4Impl :: forall a b c d e. Fn5 (Fn4 a b c d e) (Cell a) (Cell b) (Cell c) (Cell d) (Cell e)
+foreign import lift5Impl :: forall a b c d e f. Fn6 (Fn5 a b c d e f) (Cell a) (Cell b) (Cell c) (Cell d) (Cell e) (Cell f)
+foreign import lift6Impl :: forall a b c d e f g. Fn7 (Fn6 a b c d e f g) (Cell a) (Cell b) (Cell c) (Cell d) (Cell e) (Cell f) (Cell g)
 
 -- Switch
 switchC :: forall a c. (SodiumCell c) => c (Cell a) -> Effect (Cell a)

--- a/src/Cell.purs
+++ b/src/Cell.purs
@@ -32,7 +32,7 @@ import Data.Function.Uncurried (
 )
 
 -- | Sample 
-sample :: forall a c. (SodiumCell c) => c a -> Effect a
+sample :: forall a cel. (SodiumCell cel) => cel a -> Effect a
 sample c = runEffectFn1 sampleImpl (toCell c)
 
 foreign import sampleImpl :: forall a. EffectFn1 (Cell a) (a)
@@ -41,7 +41,7 @@ foreign import sampleImpl :: forall a. EffectFn1 (Cell a) (a)
 -- | Resolve the loop to specify what the CellLoop was a forward reference to. 
 -- | It must be invoked inside the same transaction as the place where the CellLoop is used.
 -- | This requires you to create an explicit transaction 
-loopCell :: forall a c. (SodiumCell c) => CellLoop a -> c a -> Effect Unit
+loopCell :: forall a cel. (SodiumCell cel) => CellLoop a -> cel a -> Effect Unit
 loopCell loopTarget c = runEffectFn2 loopCellImpl loopTarget (toCell c)
 
 foreign import loopCellImpl :: forall a. EffectFn2 (CellLoop a) (Cell a) Unit
@@ -69,10 +69,10 @@ foreign import lift5Impl :: forall a b c d e f. Fn6 (Fn5 a b c d e f) (Cell a) (
 foreign import lift6Impl :: forall a b c d e f g. Fn7 (Fn6 a b c d e f g) (Cell a) (Cell b) (Cell c) (Cell d) (Cell e) (Cell f) (Cell g)
 
 -- Switch
-switchC :: forall a c. (SodiumCell c) => c (Cell a) -> Effect (Cell a)
+switchC :: forall a cel. (SodiumCell cel) => cel (Cell a) -> Effect (Cell a)
 switchC c = runEffectFn1 switchCImpl (toCell c) 
 
-switchS :: forall a c. (SodiumCell c) => c (Stream a) -> Stream a
+switchS :: forall a cel. (SodiumCell cel) => cel (Stream a) -> Stream a
 switchS c = runFn1 switchSImpl (toCell c) 
 
 foreign import switchCImpl :: forall a. EffectFn1 (Cell (Cell a)) (Cell a)

--- a/src/Class.js
+++ b/src/Class.js
@@ -56,12 +56,12 @@ exports.listenCellImpl = function(c, listener) {
 }
 
 // Send
-exports.sendStreamImpl = function(a, streamSink) {
+exports.sendStreamImpl = function(streamSink, a) {
     //console.log("SENDING [" + a + "]");
     streamSink.send(a);
 }
 
-exports.sendCellImpl = function(a, cellSink) {
+exports.sendCellImpl = function(cellSink, a) {
     //console.log("SENDING [" + a + "]");
     cellSink.send(a);
 }

--- a/src/Class.purs
+++ b/src/Class.purs
@@ -44,7 +44,7 @@ class Listenable l where
 -- Sendable
 -- | Send events or change of behavior
 class Sendable s where
-    send :: forall a. a -> s a -> Effect Unit
+    send :: forall a. s a -> a -> Effect Unit
 
 -- | Constructors
 
@@ -142,8 +142,8 @@ instance sendStream :: Sendable StreamSink where
 instance sendCell :: Sendable CellSink where
     send = runEffectFn2 sendCellImpl
 
-foreign import sendStreamImpl :: forall a. EffectFn2 a (StreamSink a) Unit
-foreign import sendCellImpl :: forall a. EffectFn2 a (CellSink a) Unit
+foreign import sendStreamImpl :: forall a. EffectFn2 (StreamSink a) a Unit
+foreign import sendCellImpl :: forall a. EffectFn2 (CellSink a) a Unit
 
 -- Categories (Stream)
 

--- a/src/Lambda.js
+++ b/src/Lambda.js
@@ -37,19 +37,19 @@ exports.mapLambda1CellImpl = function (f, deps, c) {
     return c.map(lambda1(f, deps));
 }
 
-exports.liftLambdaImpl = function (fn, deps, c1, c) {
+exports.liftLambdaImpl = function (fn, deps, c, c1) {
     return c.lift(c1, lambda2(fn, deps));
 }
 
-exports.lift3LambdaImpl = function (fn, deps, c1, c2, c) {
+exports.lift3LambdaImpl = function (fn, deps, c, c1, c2) {
     return c.lift3(c1, c2, lambda3(fn, deps));
 }
-exports.lift4LambdaImpl = function (fn, deps, c1, c2, c3, c) {
+exports.lift4LambdaImpl = function (fn, deps, c, c1, c2, c3) {
     return c.lift4(c1, c2, c3, lambda4(fn, deps));
 }
-exports.lift5LambdaImpl = function (fn, deps, c1, c2, c3, c4, c) {
+exports.lift5LambdaImpl = function (fn, deps, c, c1, c2, c3, c4) {
     return c.lift5(c1, c2, c3, c4, lambda5(fn, deps));
 }
-exports.lift6LambdaImpl = function (fn, deps, c1, c2, c3, c4, c5, c) {
+exports.lift6LambdaImpl = function (fn, deps, c, c1, c2, c3, c4, c5) {
     return c.lift6(c1, c2, c3, c4, c5, lambda6(fn, deps));
 }

--- a/src/Lambda.js
+++ b/src/Lambda.js
@@ -11,23 +11,23 @@ exports.mapLambda1StreamImpl = function (f, deps, s) {
     return s.map(lambda1(f, deps));
 }
 
-exports.snapshotLambdaImpl = function (f, deps, c, s) {
+exports.snapshotLambdaImpl = function (f, deps, s, c) {
     return s.snapshot(c, lambda2(f, deps));
 }
 
-exports.snapshot3LambdaImpl = function (f, deps, c1, c2, s) {
+exports.snapshot3LambdaImpl = function (f, deps, s, c1, c2) {
     return s.snapshot3(c1, c2, lambda3(f, deps));
 }
 
-exports.snapshot4LambdaImpl = function (f, deps, c1, c2, c3, s) {
+exports.snapshot4LambdaImpl = function (f, deps, s, c1, c2, c3) {
     return s.snapshot4(c1, c2, c3, lambda4(f, deps));
 }
 
-exports.snapshot5LambdaImpl = function (f, deps, c1, c2, c3, c4, s) {
+exports.snapshot5LambdaImpl = function (f, deps, s, c1, c2, c3, c4) {
     return s.snapshot5(c1, c2, c3, c4, lambda5(f, deps));
 }
 
-exports.snapshot6LambdaImpl = function (f, deps, c1, c2, c3, c4, c5, s) {
+exports.snapshot6LambdaImpl = function (f, deps, s, c1, c2, c3, c4, c5) {
     return s.snapshot6(c1, c2, c3, c4, c5, lambda6(f, deps));
 }
 

--- a/src/Lambda.purs
+++ b/src/Lambda.purs
@@ -81,23 +81,23 @@ instance lambda1Cell :: Lambda1 Cell where
 foreign import mapLambda1CellImpl :: forall a b c. Fn3 (a -> b) (Array c) (Cell a) (Cell b)
 
 
-liftLambda :: forall a b c cel. (SodiumCell cel) => (a -> b -> c) -> Array Dep -> cel b -> cel a -> Cell c
+liftLambda :: forall a b c cel. (SodiumCell cel) => (a -> b -> c) -> Array Dep -> cel a -> cel b -> Cell c
 liftLambda f d c1 c2 = runFn4 liftLambdaImpl (mkFn2 f) d (toCell c1) (toCell c2)
          
-lift3Lambda :: forall a b c d cel. (SodiumCell cel) => (a -> b -> c -> d) -> Array Dep -> cel b -> cel c -> cel a -> Cell d
+lift3Lambda :: forall a b c d cel. (SodiumCell cel) => (a -> b -> c -> d) -> Array Dep -> cel a -> cel b -> cel c -> Cell d
 lift3Lambda f d c1 c2 c3 = runFn5 lift3LambdaImpl (mkFn3 f) d (toCell c1) (toCell c2) (toCell c3)
 
-lift4Lambda :: forall a b c d e cel. (SodiumCell cel) => (a -> b -> c -> d -> e) -> Array Dep -> cel b -> cel c -> cel d -> cel a -> Cell e
+lift4Lambda :: forall a b c d e cel. (SodiumCell cel) => (a -> b -> c -> d -> e) -> Array Dep -> cel a -> cel b -> cel c -> cel d -> Cell e
 lift4Lambda f d c1 c2 c3 c4 = runFn6 lift4LambdaImpl (mkFn4 f) d (toCell c1) (toCell c2) (toCell c3) (toCell c4)
 
-lift5Lambda :: forall a b c d e f cel. (SodiumCell cel) => (a -> b -> c -> d -> e -> f) -> Array Dep -> cel b -> cel c -> cel d -> cel e -> cel a -> Cell f
+lift5Lambda :: forall a b c d e f cel. (SodiumCell cel) => (a -> b -> c -> d -> e -> f) -> Array Dep -> cel a -> cel b -> cel c -> cel d -> cel e -> Cell f
 lift5Lambda f d c1 c2 c3 c4 c5 = runFn7 lift5LambdaImpl (mkFn5 f) d (toCell c1) (toCell c2) (toCell c3) (toCell c4) (toCell c5)
 
-lift6Lambda :: forall a b c d e f g cel. (SodiumCell cel) => (a -> b -> c -> d -> e -> f -> g) -> Array Dep -> cel b -> cel c -> cel d -> cel e -> cel f -> cel a -> Cell g
+lift6Lambda :: forall a b c d e f g cel. (SodiumCell cel) => (a -> b -> c -> d -> e -> f -> g) -> Array Dep -> cel a -> cel b -> cel c -> cel d -> cel e -> cel f -> Cell g
 lift6Lambda f d c1 c2 c3 c4 c5 c6 = runFn8 lift6LambdaImpl (mkFn6 f) d (toCell c1) (toCell c2) (toCell c3) (toCell c4) (toCell c5) (toCell c6)
 
-foreign import liftLambdaImpl :: forall a b c. Fn4 (Fn2 a b c) (Array Dep) (Cell b) (Cell a) (Cell c)
-foreign import lift3LambdaImpl :: forall a b c d. Fn5 (Fn3 a b c d) (Array Dep) (Cell b) (Cell c) (Cell a) (Cell d)
-foreign import lift4LambdaImpl :: forall a b c d e. Fn6 (Fn4 a b c d e) (Array Dep) (Cell b) (Cell c) (Cell d) (Cell a) (Cell e)
-foreign import lift5LambdaImpl :: forall a b c d e f. Fn7 (Fn5 a b c d e f) (Array Dep) (Cell b) (Cell c) (Cell d) (Cell e) (Cell a) (Cell f)
-foreign import lift6LambdaImpl :: forall a b c d e f g. Fn8 (Fn6 a b c d e f g) (Array Dep) (Cell b) (Cell c) (Cell d) (Cell e) (Cell f) (Cell a) (Cell g)
+foreign import liftLambdaImpl :: forall a b c. Fn4 (Fn2 a b c) (Array Dep) (Cell a) (Cell b) (Cell c)
+foreign import lift3LambdaImpl :: forall a b c d. Fn5 (Fn3 a b c d) (Array Dep) (Cell a) (Cell b) (Cell c) (Cell d)
+foreign import lift4LambdaImpl :: forall a b c d e. Fn6 (Fn4 a b c d e) (Array Dep) (Cell a) (Cell b) (Cell c) (Cell d) (Cell e)
+foreign import lift5LambdaImpl :: forall a b c d e f. Fn7 (Fn5 a b c d e f) (Array Dep) (Cell a) (Cell b) (Cell c) (Cell d) (Cell e) (Cell f)
+foreign import lift6LambdaImpl :: forall a b c d e f g. Fn8 (Fn6 a b c d e f g) (Array Dep) (Cell a) (Cell b) (Cell c) (Cell d) (Cell e) (Cell f) (Cell g)

--- a/src/Lambda.purs
+++ b/src/Lambda.purs
@@ -51,30 +51,28 @@ instance lambda1Stream :: Lambda1 Stream where
     mapLambda1 = runFn3 mapLambda1StreamImpl
 
 
-snapshotLambda :: forall a b c cel str. (SodiumStream str) => (SodiumCell cel) => (a -> b -> c) -> Array Dep -> cel b -> str a -> Stream c
-snapshotLambda f d c s = runFn4 snapshotLambdaImpl (mkFn2 f) d (toCell c) (toStream s)
+snapshotLambda :: forall a b c cel str. (SodiumStream str) => (SodiumCell cel) => (a -> b -> c) -> Array Dep -> str a -> cel b -> Stream c
+snapshotLambda f d s c = runFn4 snapshotLambdaImpl (mkFn2 f) d (toStream s) (toCell c) 
          
-snapshot3Lambda :: forall a b c d cel str. (SodiumStream str) => (SodiumCell cel) => (a -> b -> c -> d) -> Array Dep -> cel b -> cel c -> str a -> Stream d
-snapshot3Lambda f d c1 c2 s = runFn5 snapshot3LambdaImpl (mkFn3 f) d (toCell c1) (toCell c2) (toStream s)
+snapshot3Lambda :: forall a b c d cel str. (SodiumStream str) => (SodiumCell cel) => (a -> b -> c -> d) -> Array Dep -> str a -> cel b -> cel c -> Stream d
+snapshot3Lambda f d s c1 c2 = runFn5 snapshot3LambdaImpl (mkFn3 f) d (toStream s) (toCell c1) (toCell c2)
 
-snapshot4Lambda :: forall a b c d e cel str. (SodiumStream str) => (SodiumCell cel) => (a -> b -> c -> d -> e) -> Array Dep -> cel b -> cel c -> cel d -> str a -> Stream e
-snapshot4Lambda f d c1 c2 c3 s = runFn6 snapshot4LambdaImpl (mkFn4 f) d (toCell c1) (toCell c2) (toCell c3) (toStream s)
+snapshot4Lambda :: forall a b c d e cel str. (SodiumStream str) => (SodiumCell cel) => (a -> b -> c -> d -> e) -> Array Dep -> str a -> cel b -> cel c -> cel d -> Stream e
+snapshot4Lambda f d s c1 c2 c3 = runFn6 snapshot4LambdaImpl (mkFn4 f) d (toStream s) (toCell c1) (toCell c2) (toCell c3)
 
-snapshot5Lambda :: forall a b c d e f cel str. (SodiumStream str) => (SodiumCell cel) => (a -> b -> c -> d -> e -> f) -> Array Dep -> cel b -> cel c -> cel d -> cel e -> str a -> Stream f
-snapshot5Lambda f d c1 c2 c3 c4 s = runFn7 snapshot5LambdaImpl (mkFn5 f) d (toCell c1) (toCell c2) (toCell c3) (toCell c4) (toStream s)
-
-snapshot6Lambda :: forall a b c d e f g cel str. (SodiumStream str) => (SodiumCell cel) => (a -> b -> c -> d -> e -> f -> g) -> Array Dep -> cel b -> cel c -> cel d -> cel e -> cel f -> str a -> Stream g
-snapshot6Lambda f d c1 c2 c3 c4 c5 s = runFn8 snapshot6LambdaImpl (mkFn6 f) d (toCell c1) (toCell c2) (toCell c3) (toCell c4) (toCell c5) (toStream s)
-
+snapshot5Lambda :: forall a b c d e f cel str. (SodiumStream str) => (SodiumCell cel) => (a -> b -> c -> d -> e -> f) -> Array Dep -> str a -> cel b -> cel c -> cel d -> cel e -> Stream f
+snapshot5Lambda f d s c1 c2 c3 c4 = runFn7 snapshot5LambdaImpl (mkFn5 f) d (toStream s) (toCell c1) (toCell c2) (toCell c3) (toCell c4) 
+snapshot6Lambda :: forall a b c d e f g cel str. (SodiumStream str) => (SodiumCell cel) => (a -> b -> c -> d -> e -> f -> g) -> Array Dep -> str a -> cel b -> cel c -> cel d -> cel e -> cel f -> Stream g
+snapshot6Lambda f d s c1 c2 c3 c4 c5 = runFn8 snapshot6LambdaImpl (mkFn6 f) d (toStream s) (toCell c1) (toCell c2) (toCell c3) (toCell c4) (toCell c5)
 
 
 foreign import mapLambda1StreamImpl :: forall a b c. Fn3 (a -> b) (Array c) (Stream a) (Stream b)
 
-foreign import snapshotLambdaImpl :: forall a b c. Fn4 (Fn2 a b c) (Array Dep) (Cell b) (Stream a) (Stream c)
-foreign import snapshot3LambdaImpl :: forall a b c d. Fn5 (Fn3 a b c d) (Array Dep) (Cell b) (Cell c) (Stream a) (Stream d)
-foreign import snapshot4LambdaImpl :: forall a b c d e. Fn6 (Fn4 a b c d e) (Array Dep) (Cell b) (Cell c) (Cell d) (Stream a) (Stream e)
-foreign import snapshot5LambdaImpl :: forall a b c d e f. Fn7 (Fn5 a b c d e f) (Array Dep) (Cell b) (Cell c) (Cell d) (Cell e) (Stream a) (Stream f)
-foreign import snapshot6LambdaImpl :: forall a b c d e f g. Fn8 (Fn6 a b c d e f g) (Array Dep) (Cell b) (Cell c) (Cell d) (Cell e) (Cell f) (Stream a) (Stream g)
+foreign import snapshotLambdaImpl :: forall a b c. Fn4 (Fn2 a b c) (Array Dep) (Stream a) (Cell b) (Stream c)
+foreign import snapshot3LambdaImpl :: forall a b c d. Fn5 (Fn3 a b c d) (Array Dep) (Stream a) (Cell b) (Cell c) (Stream d)
+foreign import snapshot4LambdaImpl :: forall a b c d e. Fn6 (Fn4 a b c d e) (Array Dep) (Stream a) (Cell b) (Cell c) (Cell d) (Stream e)
+foreign import snapshot5LambdaImpl :: forall a b c d e f. Fn7 (Fn5 a b c d e f) (Array Dep) (Stream a) (Cell b) (Cell c) (Cell d) (Cell e) (Stream f)
+foreign import snapshot6LambdaImpl :: forall a b c d e f g. Fn8 (Fn6 a b c d e f g) (Array Dep) (Stream a) (Cell b) (Cell c) (Cell d) (Cell e) (Cell f) (Stream g)
 
 -- Cell 
 instance lambda1Cell :: Lambda1 Cell where

--- a/src/Operational.purs
+++ b/src/Operational.purs
@@ -23,7 +23,7 @@ import Data.Function.Uncurried ( Fn1, runFn1)
 -- | It breaks the property of non-detectability of cell steps/updates.
 -- | The rule with this primitive is that you should only use it in functions
 -- | that do not allow the caller to detect the cell updates.
-updates :: forall a c. (SodiumCell c) => c a -> Stream a
+updates :: forall a cel. (SodiumCell cel) => cel a -> Stream a
 updates c = runFn1 updatesImpl (toCell c)
 
 -- | A stream that is guaranteed to fire once in the transaction where value() is invoked, giving
@@ -34,12 +34,12 @@ updates c = runFn1 updatesImpl (toCell c)
 -- | It breaks the property of non-detectability of cell steps/updates.
 -- | The rule with this primitive is that you should only use it in functions
 -- | that do not allow the caller to detect the cell updates.
-value :: forall a c. (SodiumCell c) => c a -> Effect (Stream a)
+value :: forall a cel. (SodiumCell cel) => cel a -> Effect (Stream a)
 value c = runEffectFn1 valueImpl (toCell c)
 
 -- | Push each event onto a new transaction guaranteed to come before the next externally
 -- | initiated transaction. Same as 'split' but it works on a single value.
-defer :: forall a s. (SodiumStream s) => s a -> Stream a
+defer :: forall a str. (SodiumStream str) => str a -> Stream a
 defer s = runFn1 deferImpl (toStream s)
 
 -- | Push each event in the list onto a newly created transaction guaranteed
@@ -47,7 +47,7 @@ defer s = runFn1 deferImpl (toStream s)
 -- | are such that two different invocations of split() can put events into the same
 -- | new transaction, so the resulting stream's events could be simultaneous with
 -- | events output by split() or 'defer' invoked elsewhere in the code.
-split :: forall a s. (SodiumStream s) => s (Array a) -> Stream a
+split :: forall a str. (SodiumStream str) => str (Array a) -> Stream a
 split sa = runFn1 splitImpl (toStream sa)
 
 foreign import updatesImpl :: forall a. Fn1 (Cell a) (Stream a)

--- a/src/Stream.js
+++ b/src/Stream.js
@@ -66,7 +66,7 @@ exports.onceImpl = function(s) {
     return s.once();
 }
 
-exports.loopStreamImpl = function(s, sLoop) {
+exports.loopStreamImpl = function(sLoop, s) {
     sLoop.loop(s);
 }
 

--- a/src/Stream.js
+++ b/src/Stream.js
@@ -19,7 +19,7 @@ exports.filterImpl = function(f, s) {
     return s.filter(f); 
 }
 
-exports.gateImpl = function (c, s) {
+exports.gateImpl = function (s, c) {
     return s.gate(c);
 }
 

--- a/src/Stream.js
+++ b/src/Stream.js
@@ -3,7 +3,7 @@ const Sodium = require("sodiumjs");
 
 const Tuple2 = Sodium.Tuple2;
 
-exports.mapToImpl = function(s, x) {
+exports.mapToImpl = function(x, s) {
     return s.mapTo(x);
 }
 

--- a/src/Stream.js
+++ b/src/Stream.js
@@ -24,27 +24,27 @@ exports.gateImpl = function (c, s) {
     return s.gate(c);
 }
 
-exports.snapshot1Impl = function (c, s) {
+exports.snapshot1Impl = function (s, c) {
     return s.snapshot1(c);
 }
 
-exports.snapshotImpl = function (fn, c, s) {
+exports.snapshotImpl = function (fn, s, c) {
     return s.snapshot(c, fn);
 }
 
-exports.snapshot3Impl = function (fn, c1, c2, s) {
+exports.snapshot3Impl = function (fn, s, c1, c2) {
     return s.snapshot3(c1, c2, fn);
 }
 
-exports.snapshot4Impl = function (fn, c1, c2, c3, s) {
+exports.snapshot4Impl = function (fn, s, c1, c2, c3) {
     return s.snapshot4(c1, c2, c3, fn);
 }
 
-exports.snapshot5Impl = function (fn, c1, c2, c3, c4, s) {
+exports.snapshot5Impl = function (fn, s, c1, c2, c3, c4) {
     return s.snapshot5(c1, c2, c3, c4, fn);
 }
 
-exports.snapshot6Impl = function (fn, c1, c2, c3, c4, c5, s) {
+exports.snapshot6Impl = function (fn, s, c1, c2, c3, c4, c5) {
     return s.snapshot6(c1, c2, c3, c4, c5, fn);
 }
 

--- a/src/Stream.js
+++ b/src/Stream.js
@@ -11,9 +11,8 @@ exports.orElseImpl = function(s, other) {
     return s.orElse(other);
 }
 
-exports.mergeImpl = function(f, other, s) {
-    //flipped so that other's events are on the left
-    return other.merge(s, f);
+exports.mergeImpl = function(f, s, other) {
+    return s.merge(other, f);
 }
 
 exports.filterImpl = function(f, s) {

--- a/src/Stream.js
+++ b/src/Stream.js
@@ -7,7 +7,7 @@ exports.mapToImpl = function(x, s) {
     return s.mapTo(x);
 }
 
-exports.orElseImpl = function(other, s) {
+exports.orElseImpl = function(s, other) {
     return s.orElse(other);
 }
 

--- a/src/Stream.js
+++ b/src/Stream.js
@@ -3,7 +3,7 @@ const Sodium = require("sodiumjs");
 
 const Tuple2 = Sodium.Tuple2;
 
-exports.mapToImpl = function(x, s) {
+exports.mapToImpl = function(s, x) {
     return s.mapTo(x);
 }
 

--- a/src/Stream.js
+++ b/src/Stream.js
@@ -47,7 +47,7 @@ exports.snapshot6Impl = function (fn, s, c1, c2, c3, c4, c5) {
     return s.snapshot6(c1, c2, c3, c4, c5, fn);
 }
 
-exports.holdImpl = function (x, s) {
+exports.holdImpl = function (s, x) {
     return s.hold(x);
 }
 

--- a/src/Stream.purs
+++ b/src/Stream.purs
@@ -46,8 +46,8 @@ import Effect.Unsafe (unsafePerformEffect)
 
 -- | Transform the stream's event values into the specified constant value.
 -- | b is a constant value.
-mapTo :: forall a b s. (SodiumStream s) => s a -> b -> Stream b
-mapTo s x = runFn2 mapToImpl (toStream s) x
+mapTo :: forall a b s. (SodiumStream s) => b -> s a -> Stream b
+mapTo x s = runFn2 mapToImpl x (toStream s)
 
 -- | Variant of 'merge' that merges two streams and will drop an event
 -- | in the simultaneous case of two events in the same Transaction
@@ -149,7 +149,7 @@ execute s = map unsafePerformEffect (toStream s)
 
 -- Foreign imports
 
-foreign import mapToImpl :: forall a b. Fn2 (Stream a) b (Stream b)
+foreign import mapToImpl :: forall a b. Fn2 b (Stream a) (Stream b)
 foreign import orElseImpl :: forall a. Fn2 (Stream a) (Stream a) (Stream a)
 foreign import mergeImpl :: forall a. Fn3 (Fn2 a a a) (Stream a) (Stream a) (Stream a)
 foreign import filterImpl :: forall a. Fn2 (a -> Boolean) (Stream a) (Stream a)

--- a/src/Stream.purs
+++ b/src/Stream.purs
@@ -75,8 +75,8 @@ filter f s = runFn2 filterImpl f (toStream s)
 
 -- | Return a stream that only outputs events from the input stream
 -- | when the specified cell's value is true.
-gate :: forall a s c. (SodiumStream s) => (SodiumCell c) => c Boolean -> s a -> Stream a
-gate c s = runFn2 gateImpl (toCell c) (toStream s)
+gate :: forall a s c. (SodiumStream s) => (SodiumCell c) => s a -> c Boolean -> Stream a
+gate s c = runFn2 gateImpl (toStream s) (toCell c) 
 
 
 -- | Variant of 'snapshot' that captures the cell's value
@@ -152,7 +152,7 @@ foreign import mapToImpl :: forall a b. Fn2 b (Stream a) (Stream b)
 foreign import orElseImpl :: forall a. Fn2 (Stream a) (Stream a) (Stream a)
 foreign import mergeImpl :: forall a. Fn3 (Fn2 a a a) (Stream a) (Stream a) (Stream a)
 foreign import filterImpl :: forall a. Fn2 (a -> Boolean) (Stream a) (Stream a)
-foreign import gateImpl :: forall a. Fn2 (Cell Boolean) (Stream a) (Stream a)
+foreign import gateImpl :: forall a. Fn2 (Stream a) (Cell Boolean) (Stream a)
 foreign import snapshot1Impl :: forall a. Fn2 (Stream a) (Cell a) (Stream a)
 foreign import snapshotImpl :: forall a b c. Fn3 (Fn2 a b c) (Stream a) (Cell b) (Stream c)
 foreign import snapshot3Impl :: forall a b c d. Fn4 (Fn3 a b c d) (Stream a) (Cell b) (Cell c) (Stream d)

--- a/src/Stream.purs
+++ b/src/Stream.purs
@@ -46,7 +46,7 @@ import Effect.Unsafe (unsafePerformEffect)
 
 -- | Transform the stream's event values into the specified constant value.
 -- | b is a constant value.
-mapTo :: forall a b s. (SodiumStream s) => b -> s a -> Stream b
+mapTo :: forall a b str. (SodiumStream str) => b -> str a -> Stream b
 mapTo x s = runFn2 mapToImpl x (toStream s)
 
 -- | Variant of 'merge' that merges two streams and will drop an event
@@ -56,7 +56,7 @@ mapTo x s = runFn2 mapToImpl x (toStream s)
 -- | In other words it's eqivilent to `merge (\l r -> l) s1 s2`
 -- |
 -- | If you want to specify your own merging function, use 'merge'
-orElse :: forall a s. (SodiumStream s) => s a -> s a -> Stream a
+orElse :: forall a str. (SodiumStream str) => str a -> str a -> Stream a
 orElse s1 s2 = runFn2 orElseImpl (toStream s1) (toStream s2)
 
 
@@ -67,22 +67,22 @@ orElse s1 s2 = runFn2 orElseImpl (toStream s1) (toStream s2)
 -- |
 -- | It may construct FRP logic or use sample()
 -- | Apart from this the function must be referentially transparent.
-merge :: forall a s. (SodiumStream s) => (a -> a -> a) -> s a -> s a -> Stream a
+merge :: forall a str. (SodiumStream str) => (a -> a -> a) -> str a -> str a -> Stream a
 merge f s1 s2 = runFn3 mergeImpl (mkFn2 f) (toStream s1) (toStream s2)
 
 -- | Return a stream that only outputs events for which the predicate returns true.
-filter :: forall a s. (SodiumStream s) => (a -> Boolean) -> s a -> Stream a
+filter :: forall a str. (SodiumStream str) => (a -> Boolean) -> str a -> Stream a
 filter f s = runFn2 filterImpl f (toStream s)
 
 -- | Return a stream that only outputs events from the input stream
 -- | when the specified cell's value is true.
-gate :: forall a s c. (SodiumStream s) => (SodiumCell c) => s a -> c Boolean -> Stream a
+gate :: forall a str cel. (SodiumStream str) => (SodiumCell cel) => str a -> cel Boolean -> Stream a
 gate s c = runFn2 gateImpl (toStream s) (toCell c) 
 
 
 -- | Variant of 'snapshot' that captures the cell's value
 -- | at the time of the event firing, ignoring the stream's value.
-snapshot1 :: forall a s c. (SodiumStream s) => (SodiumCell c) => s a -> c a -> Stream a
+snapshot1 :: forall a str cel. (SodiumStream str) => (SodiumCell cel) => str a -> cel a -> Stream a
 snapshot1 s c = runFn2 snapshot1Impl (toStream s) (toCell c)
 
 -- | Return a stream whose events are the result of the combination using the specified
@@ -112,7 +112,7 @@ snapshot6 f s c1 c2 c3 c4 c5 = runFn7 snapshot6Impl (mkFn6 f) (toStream s) (toCe
 -- | visible as the cell's current value as viewed by 'snapshot' until the following transaction. 
 -- | To put this another way, 'snapshot' always sees the value of a cell as it was before
 -- | any state changes from the current transaction.
-hold :: forall a s. (SodiumStream s) => s a -> a -> Effect (Cell a)
+hold :: forall a str. (SodiumStream str) => str a -> a -> Effect (Cell a)
 hold s x = runEffectFn2 holdImpl (toStream s) x 
 
 -- | Transform an event with a generalized state loop (a Mealy machine). The function
@@ -120,7 +120,7 @@ hold s x = runEffectFn2 holdImpl (toStream s) x
 -- | The function may construct FRP logic or use 'sample' in which case 
 -- | it is equivalent to 'snapshot'ing the cell. 
 -- | Apart from this the function must be referentially transparent.
-collect :: forall a b c s. (SodiumStream s) => (a -> c -> {value :: b, state :: c}) -> c -> s a -> Stream b
+collect :: forall a b c str. (SodiumStream str) => (a -> c -> {value :: b, state :: c}) -> c -> str a -> Stream b
 collect f x s = runFn3 collectImpl (mkFn2 f) x (toStream s)
 
 
@@ -128,23 +128,23 @@ collect f x s = runFn3 collectImpl (mkFn2 f) x (toStream s)
 -- | The function may construct FRP logic or use 'sample' 
 -- | in which case it is equivalent to 'snapshot'ing the cell. 
 -- | Apart from this the function must be referentially transparent.
-accum :: forall a b s. (SodiumStream s) => (a -> b -> b) -> b -> s a -> Cell b
+accum :: forall a b str. (SodiumStream str) => (a -> b -> b) -> b -> str a -> Cell b
 accum f x s = runFn3 accumImpl (mkFn2 f) x (toStream s)
 
 -- | Return a stream that outputs only one value: the next event of the
 -- | input stream, starting from the transaction in which once() was invoked.
-once :: forall a s. (SodiumStream s) => s a -> Stream a
+once :: forall a str. (SodiumStream str) => str a -> Stream a
 once s = runFn1 onceImpl (toStream s)
 
 -- | Resolve the loop to specify what the StreamLoop was a forward reference to. 
 -- | It must be invoked inside the same transaction as the place where the StreamLoop is used.
 -- | This requires you to create an explicit transaction 
-loopStream :: forall a s. (SodiumStream s) => StreamLoop a -> s a -> Effect Unit
+loopStream :: forall a str. (SodiumStream str) => StreamLoop a -> str a -> Effect Unit
 loopStream loopTarget s = runEffectFn2 loopStreamImpl loopTarget (toStream s)
 
 -- | Runs the side effects as a map over stream events
 -- | This is a safe thing to do in Sodium
-execute :: forall a s. (SodiumStream s) => s (Effect a) -> Stream a
+execute :: forall a str. (SodiumStream str) => str (Effect a) -> Stream a
 execute s = map unsafePerformEffect (toStream s)
 
 -- Foreign imports

--- a/src/Stream.purs
+++ b/src/Stream.purs
@@ -53,6 +53,7 @@ mapTo s x = runFn2 mapToImpl (toStream s) x
 -- | in the simultaneous case of two events in the same Transaction
 -- |
 -- | The events from the first stream take priority here
+-- | In other words it's eqivilent to `merge (\l r -> l) s1 s2`
 -- |
 -- | If you want to specify your own merging function, use 'merge'
 orElse :: forall a s. (SodiumStream s) => s a -> s a -> Stream a

--- a/src/Stream.purs
+++ b/src/Stream.purs
@@ -52,7 +52,7 @@ mapTo x s = runFn2 mapToImpl x (toStream s)
 -- | Variant of 'merge' that merges two streams and will drop an event
 -- | in the simultaneous case of two events in the same Transaction
 -- |
--- | The events from the second stream take priority here
+-- | The events from the first stream take priority here
 -- |
 -- | If you want to specify your own merging function, use 'merge'
 orElse :: forall a s. (SodiumStream s) => s a -> s a -> Stream a

--- a/src/Stream.purs
+++ b/src/Stream.purs
@@ -81,8 +81,8 @@ gate c s = runFn2 gateImpl (toCell c) (toStream s)
 
 -- | Variant of 'snapshot' that captures the cell's value
 -- | at the time of the event firing, ignoring the stream's value.
-snapshot1 :: forall a s c. (SodiumStream s) => (SodiumCell c) => c a -> s a -> Stream a
-snapshot1 c s = runFn2 snapshot1Impl (toCell c) (toStream s)
+snapshot1 :: forall a s c. (SodiumStream s) => (SodiumCell c) => s a -> c a -> Stream a
+snapshot1 s c = runFn2 snapshot1Impl (toStream s) (toCell c)
 
 -- | Return a stream whose events are the result of the combination using the specified
 -- | function of the input stream's event value and the value of the cell at that time.
@@ -91,21 +91,20 @@ snapshot1 c s = runFn2 snapshot1Impl (toCell c) (toStream s)
 -- | 'hold' don't become visible as the cell's current value until the following transaction. 
 -- | To put this another way, 'snapshot' always sees the value of a cell as it was 
 -- | before any state changes from the current transaction.
-snapshot :: forall a b c cel str. (SodiumStream str) => (SodiumCell cel) => (a -> b -> c) -> cel b -> str a -> Stream c
-snapshot f c s = runFn3 snapshotImpl (mkFn2 f) (toCell c) (toStream s)
+snapshot :: forall a b c cel str. (SodiumStream str) => (SodiumCell cel) => (a -> b -> c) -> str a -> cel b -> Stream c
+snapshot f s c = runFn3 snapshotImpl (mkFn2 f) (toStream s) (toCell c) 
          
-snapshot3 :: forall a b c d cel str. (SodiumStream str) => (SodiumCell cel) => (a -> b -> c -> d) -> cel b -> cel c -> str a -> Stream d
-snapshot3 f c1 c2 s = runFn4 snapshot3Impl (mkFn3 f) (toCell c1) (toCell c2) (toStream s)
+snapshot3 :: forall a b c d cel str. (SodiumStream str) => (SodiumCell cel) => (a -> b -> c -> d) -> str a -> cel b -> cel c -> Stream d
+snapshot3 f s c1 c2 = runFn4 snapshot3Impl (mkFn3 f) (toStream s) (toCell c1) (toCell c2) 
 
-snapshot4 :: forall a b c d e cel str. (SodiumStream str) => (SodiumCell cel) => (a -> b -> c -> d -> e) -> cel b -> cel c -> cel d -> str a -> Stream e
-snapshot4 f c1 c2 c3 s = runFn5 snapshot4Impl (mkFn4 f) (toCell c1) (toCell c2) (toCell c3) (toStream s)
+snapshot4 :: forall a b c d e cel str. (SodiumStream str) => (SodiumCell cel) => (a -> b -> c -> d -> e) -> str a -> cel b -> cel c -> cel d -> Stream e
+snapshot4 f s c1 c2 c3 = runFn5 snapshot4Impl (mkFn4 f) (toStream s) (toCell c1) (toCell c2) (toCell c3) 
 
-snapshot5 :: forall a b c d e f cel str. (SodiumStream str) => (SodiumCell cel) => (a -> b -> c -> d -> e -> f) -> cel b -> cel c -> cel d -> cel e -> str a -> Stream f
-snapshot5 f c1 c2 c3 c4 s = runFn6 snapshot5Impl (mkFn5 f) (toCell c1) (toCell c2) (toCell c3) (toCell c4) (toStream s)
+snapshot5 :: forall a b c d e f cel str. (SodiumStream str) => (SodiumCell cel) => (a -> b -> c -> d -> e -> f) -> str a -> cel b -> cel c -> cel d -> cel e -> Stream f
+snapshot5 f s c1 c2 c3 c4 = runFn6 snapshot5Impl (mkFn5 f) (toStream s) (toCell c1) (toCell c2) (toCell c3) (toCell c4) 
 
-snapshot6 :: forall a b c d e f g cel str. (SodiumStream str) => (SodiumCell cel) => (a -> b -> c -> d -> e -> f -> g) -> cel b -> cel c -> cel d -> cel e -> cel f -> str a -> Stream g
-snapshot6 f c1 c2 c3 c4 c5 s = runFn7 snapshot6Impl (mkFn6 f) (toCell c1) (toCell c2) (toCell c3) (toCell c4) (toCell c5) (toStream s)
-
+snapshot6 :: forall a b c d e f g cel str. (SodiumStream str) => (SodiumCell cel) => (a -> b -> c -> d -> e -> f -> g) -> str a -> cel b -> cel c -> cel d -> cel e -> cel f -> Stream g
+snapshot6 f s c1 c2 c3 c4 c5 = runFn7 snapshot6Impl (mkFn6 f) (toStream s) (toCell c1) (toCell c2) (toCell c3) (toCell c4) (toCell c5) 
 
 -- | Create a "Cell" with the specified initial value, that is updated by this stream's event values.
 -- | There is an implicit delay: State updates caused by event firings don't become
@@ -154,12 +153,12 @@ foreign import orElseImpl :: forall a. Fn2 (Stream a) (Stream a) (Stream a)
 foreign import mergeImpl :: forall a. Fn3 (Fn2 a a a) (Stream a) (Stream a) (Stream a)
 foreign import filterImpl :: forall a. Fn2 (a -> Boolean) (Stream a) (Stream a)
 foreign import gateImpl :: forall a. Fn2 (Cell Boolean) (Stream a) (Stream a)
-foreign import snapshot1Impl :: forall a. Fn2 (Cell a) (Stream a) (Stream a)
-foreign import snapshotImpl :: forall a b c. Fn3 (Fn2 a b c) (Cell b) (Stream a) (Stream c)
-foreign import snapshot3Impl :: forall a b c d. Fn4 (Fn3 a b c d) (Cell b) (Cell c) (Stream a) (Stream d)
-foreign import snapshot4Impl :: forall a b c d e. Fn5 (Fn4 a b c d e) (Cell b) (Cell c) (Cell d) (Stream a) (Stream e)
-foreign import snapshot5Impl :: forall a b c d e f. Fn6 (Fn5 a b c d e f) (Cell b) (Cell c) (Cell d) (Cell e) (Stream a) (Stream f)
-foreign import snapshot6Impl :: forall a b c d e f g. Fn7 (Fn6 a b c d e f g) (Cell b) (Cell c) (Cell d) (Cell e) (Cell f) (Stream a) (Stream g)
+foreign import snapshot1Impl :: forall a. Fn2 (Stream a) (Cell a) (Stream a)
+foreign import snapshotImpl :: forall a b c. Fn3 (Fn2 a b c) (Stream a) (Cell b) (Stream c)
+foreign import snapshot3Impl :: forall a b c d. Fn4 (Fn3 a b c d) (Stream a) (Cell b) (Cell c) (Stream d)
+foreign import snapshot4Impl :: forall a b c d e. Fn5 (Fn4 a b c d e) (Stream a) (Cell b) (Cell c) (Cell d) (Stream e)
+foreign import snapshot5Impl :: forall a b c d e f. Fn6 (Fn5 a b c d e f) (Stream a) (Cell b) (Cell c) (Cell d) (Cell e) (Stream f)
+foreign import snapshot6Impl :: forall a b c d e f g. Fn7 (Fn6 a b c d e f g) (Stream a) (Cell b) (Cell c) (Cell d) (Cell e) (Cell f) (Stream g)
 foreign import holdImpl :: forall a. EffectFn2 a (Stream a) (Cell a)
 foreign import collectImpl :: forall a b c. Fn3 (Fn2 a c {value :: b, state :: c}) c (Stream a) (Stream b)
 foreign import accumImpl :: forall a b. Fn3 (Fn2 a b b) b (Stream a) (Cell b)

--- a/src/Stream.purs
+++ b/src/Stream.purs
@@ -111,8 +111,8 @@ snapshot6 f s c1 c2 c3 c4 c5 = runFn7 snapshot6Impl (mkFn6 f) (toStream s) (toCe
 -- | visible as the cell's current value as viewed by 'snapshot' until the following transaction. 
 -- | To put this another way, 'snapshot' always sees the value of a cell as it was before
 -- | any state changes from the current transaction.
-hold :: forall a s. (SodiumStream s) => a -> s a -> Effect (Cell a)
-hold x s = runEffectFn2 holdImpl x (toStream s)
+hold :: forall a s. (SodiumStream s) => s a -> a -> Effect (Cell a)
+hold s x = runEffectFn2 holdImpl (toStream s) x 
 
 -- | Transform an event with a generalized state loop (a Mealy machine). The function
 -- | is passed the input and the old state and returns the new state and output value.
@@ -159,7 +159,7 @@ foreign import snapshot3Impl :: forall a b c d. Fn4 (Fn3 a b c d) (Stream a) (Ce
 foreign import snapshot4Impl :: forall a b c d e. Fn5 (Fn4 a b c d e) (Stream a) (Cell b) (Cell c) (Cell d) (Stream e)
 foreign import snapshot5Impl :: forall a b c d e f. Fn6 (Fn5 a b c d e f) (Stream a) (Cell b) (Cell c) (Cell d) (Cell e) (Stream f)
 foreign import snapshot6Impl :: forall a b c d e f g. Fn7 (Fn6 a b c d e f g) (Stream a) (Cell b) (Cell c) (Cell d) (Cell e) (Cell f) (Stream g)
-foreign import holdImpl :: forall a. EffectFn2 a (Stream a) (Cell a)
+foreign import holdImpl :: forall a. EffectFn2 (Stream a) a (Cell a)
 foreign import collectImpl :: forall a b c. Fn3 (Fn2 a c {value :: b, state :: c}) c (Stream a) (Stream b)
 foreign import accumImpl :: forall a b. Fn3 (Fn2 a b b) b (Stream a) (Cell b)
 foreign import onceImpl :: forall a. Fn1 (Stream a) (Stream a)

--- a/src/Stream.purs
+++ b/src/Stream.purs
@@ -138,8 +138,8 @@ once s = runFn1 onceImpl (toStream s)
 -- | Resolve the loop to specify what the StreamLoop was a forward reference to. 
 -- | It must be invoked inside the same transaction as the place where the StreamLoop is used.
 -- | This requires you to create an explicit transaction 
-loopStream :: forall a s. (SodiumStream s) => s a -> StreamLoop a -> Effect Unit
-loopStream s = runEffectFn2 loopStreamImpl (toStream s)
+loopStream :: forall a s. (SodiumStream s) => StreamLoop a -> s a -> Effect Unit
+loopStream loopTarget s = runEffectFn2 loopStreamImpl loopTarget (toStream s)
 
 -- | Runs the side effects as a map over stream events
 -- | This is a safe thing to do in Sodium
@@ -163,4 +163,4 @@ foreign import holdImpl :: forall a. EffectFn2 (Stream a) a (Cell a)
 foreign import collectImpl :: forall a b c. Fn3 (Fn2 a c {value :: b, state :: c}) c (Stream a) (Stream b)
 foreign import accumImpl :: forall a b. Fn3 (Fn2 a b b) b (Stream a) (Cell b)
 foreign import onceImpl :: forall a. Fn1 (Stream a) (Stream a)
-foreign import loopStreamImpl :: forall a. EffectFn2 (Stream a) (StreamLoop a) Unit
+foreign import loopStreamImpl :: forall a. EffectFn2 (StreamLoop a) (Stream a) Unit

--- a/src/Stream.purs
+++ b/src/Stream.purs
@@ -46,8 +46,8 @@ import Effect.Unsafe (unsafePerformEffect)
 
 -- | Transform the stream's event values into the specified constant value.
 -- | b is a constant value.
-mapTo :: forall a b s. (SodiumStream s) => b -> s a -> Stream b
-mapTo x s = runFn2 mapToImpl x (toStream s)
+mapTo :: forall a b s. (SodiumStream s) => s a -> b -> Stream b
+mapTo s x = runFn2 mapToImpl (toStream s) x
 
 -- | Variant of 'merge' that merges two streams and will drop an event
 -- | in the simultaneous case of two events in the same Transaction
@@ -148,7 +148,7 @@ execute s = map unsafePerformEffect (toStream s)
 
 -- Foreign imports
 
-foreign import mapToImpl :: forall a b. Fn2 b (Stream a) (Stream b)
+foreign import mapToImpl :: forall a b. Fn2 (Stream a) b (Stream b)
 foreign import orElseImpl :: forall a. Fn2 (Stream a) (Stream a) (Stream a)
 foreign import mergeImpl :: forall a. Fn3 (Fn2 a a a) (Stream a) (Stream a) (Stream a)
 foreign import filterImpl :: forall a. Fn2 (a -> Boolean) (Stream a) (Stream a)

--- a/test/Cell.test.purs
+++ b/test/Cell.test.purs
@@ -65,7 +65,7 @@ testCell = runTest do
                     Ref.modify_ (\xs -> snoc xs value) refList
                     xs <- Ref.read refList
                     if (length xs == 2) then (cb $ Right xs) else (pure unit)
-                send 4 a
+                send a 4
                 unlisten
                 pure nonCanceler 
             )
@@ -156,7 +156,7 @@ testCell = runTest do
             result <- makeAff \cb -> do
                 unlisten <- listen s2 \value ->
                     cb $ Right value 
-                send 2 s1
+                send s1 2
                 unlisten
                 pure nonCanceler 
             Assert.equal result 2

--- a/test/Lambda.test.purs
+++ b/test/Lambda.test.purs
@@ -41,7 +41,7 @@ testLambda = runTest do
             result <- makeAff \cb -> do
                 unlisten <- listen c \value ->
                     cb $ Right value 
-                send 3 a
+                send a 3
                 unlisten
                 pure nonCanceler 
             Assert.equal result 5
@@ -55,7 +55,7 @@ testLambda = runTest do
             result <- makeAff \cb -> do
                 unlisten <- listen c \value ->
                     cb $ Right value 
-                send 3 a
+                send a 3
                 unlisten
                 pure nonCanceler 
             Assert.equal result 7

--- a/test/Lambda.test.purs
+++ b/test/Lambda.test.purs
@@ -64,8 +64,7 @@ testLambda = runTest do
             let c = liftLambda
                         ((\x y -> x + y + (unsafePerformEffect $ sample b))) 
                         [mkDep b]
-                        (b)
-                        (newCell 3)
+                        (newCell 3) b
             result <- makeAff \cb -> do
                 unlisten <- listen c \value ->
                     cb $ Right value 

--- a/test/Lambda.test.purs
+++ b/test/Lambda.test.purs
@@ -51,8 +51,7 @@ testLambda = runTest do
             let c = snapshotLambda
                         ((\x -> \y -> x + y + (unsafePerformEffect $ sample b))) 
                         [mkDep a, mkDep b]
-                        (b)
-                        a 
+                        a b
             result <- makeAff \cb -> do
                 unlisten <- listen c \value ->
                     cb $ Right value 

--- a/test/Operational.test.purs
+++ b/test/Operational.test.purs
@@ -39,8 +39,8 @@ testOperational = runTest do
                     Ref.modify_ (\xs -> snoc xs v) refList
                     xs <- Ref.read refList
                     if (length xs == 2) then (cb $ Right xs) else (pure unit)
-                send 2 a
-                send 3 a
+                send a 2
+                send a 3
                 unlisten
                 pure nonCanceler 
             Assert.equal (fromFoldable [2, 3]) results
@@ -58,7 +58,7 @@ testOperational = runTest do
                         pure nonCanceler
                     pure unit 
                 )
-                send 3 a 
+                send a 3
                 pure nonCanceler
             Assert.equal (fromFoldable [2, 3]) results
         test "defer" do
@@ -70,8 +70,8 @@ testOperational = runTest do
                     Ref.modify_ (\xs -> snoc xs value) refList
                     xs <- Ref.read refList
                     if (length xs == 2) then (cb $ Right xs) else (pure unit)
-                send 2 a
-                send 3 a
+                send a 2
+                send a 3
                 unlisten
                 pure nonCanceler 
             Assert.equal (fromFoldable [2, 3]) results
@@ -84,7 +84,7 @@ testOperational = runTest do
                     Ref.modify_ (\xs -> snoc xs value) refList
                     xs <- Ref.read refList
                     if (length xs == 2) then (cb $ Right xs) else (pure unit)
-                send [2,3] a
+                send a [2,3] 
                 unlisten
                 pure nonCanceler 
             Assert.equal (fromFoldable [2, 3]) results

--- a/test/Stream.test.purs
+++ b/test/Stream.test.purs
@@ -83,7 +83,7 @@ testStream = runTest do
 
         test "mapTo" do
             a <- liftEffect $ newStreamSink Nothing
-            let b = mapTo 4 a
+            let b = mapTo a 4
             result <- makeAff \cb -> do
                 unlisten <- listen b \value ->
                     cb $ Right value 

--- a/test/Stream.test.purs
+++ b/test/Stream.test.purs
@@ -200,7 +200,7 @@ testStream = runTest do
         test "snapshot1" do
             a <- liftEffect $ newStreamSink Nothing
             let b = newCell 2
-            let c = snapshot1 b (a :: StreamSink Int)
+            let c = snapshot1 (a :: StreamSink Int) b
             result <- makeAff \cb -> do
                 unlisten <- listen c \value ->
                     cb $ Right value 
@@ -211,7 +211,7 @@ testStream = runTest do
         test "snapshot" do
             a <- liftEffect $ newStreamSink Nothing
             let b = newCell 2
-            let c = snapshot (\x1 -> \x2 -> x1 + x2) b (a :: StreamSink Int)
+            let c = snapshot (\x1 -> \x2 -> x1 + x2) (a :: StreamSink Int) b
             result <- makeAff \cb -> do
                 unlisten <- listen c \value ->
                     cb $ Right value 
@@ -225,7 +225,7 @@ testStream = runTest do
             let c = newCell 3
             let d = snapshot3 
                     (\x1 -> \x2 -> \x3 -> x1 + x2 + x3) 
-                    b c a 
+                    a b c 
             result <- makeAff \cb -> do
                 unlisten <- listen d \value ->
                     cb $ Right value 
@@ -240,7 +240,7 @@ testStream = runTest do
             let d = newCell 4
             let e = snapshot4 
                     (\x1 -> \x2 -> \x3 -> \x4 -> x1 + x2 + x3 + x4) 
-                    b c d a
+                    a b c d
             result <- makeAff \cb -> do
                 unlisten <- listen e \value ->
                     cb $ Right value 
@@ -258,7 +258,7 @@ testStream = runTest do
                     (\x1 -> \x2 -> \x3 -> \x4 -> \x5 ->
                         x1 + x2 + x3 + x4 + x5
                     ) 
-                    b c d e a
+                    a b c d e
             result <- makeAff \cb -> do
                 unlisten <- listen f \value ->
                     cb $ Right value 
@@ -277,7 +277,7 @@ testStream = runTest do
                     (\x1 -> \x2 -> \x3 -> \x4 -> \x5 -> \x6 -> 
                         x1 + x2 + x3 + x4 + x5 + x6
                     ) 
-                    b c d e f a
+                    a b c d e f
             result <- makeAff \cb -> do
                 unlisten <- listen g \value ->
                     cb $ Right value 

--- a/test/Stream.test.purs
+++ b/test/Stream.test.purs
@@ -288,7 +288,7 @@ testStream = runTest do
     suite "[stream] hold" do
         test "hold" do
             a <- liftEffect $ newStreamSink Nothing
-            b <- liftEffect $ hold 2 a 
+            b <- liftEffect $ hold a 2
             result <- makeAff \cb -> do
                 unlisten <- listen b \value ->
                     cb $ Right value 

--- a/test/Stream.test.purs
+++ b/test/Stream.test.purs
@@ -130,8 +130,8 @@ testStream = runTest do
                     cb $ Right value 
                 runTransaction (
                     do 
-                        send 2 a
-                        send 3 b
+                        send 3 a
+                        send 2 b
                 )
                 unlisten
                 pure nonCanceler 

--- a/test/Stream.test.purs
+++ b/test/Stream.test.purs
@@ -51,7 +51,7 @@ testStream = runTest do
             result <- makeAff \cb -> do
                 unlisten <- listen a \value ->
                     cb $ Right value 
-                send 2 a
+                send a 2
                 unlisten
                 pure nonCanceler 
             Assert.equal result 2
@@ -61,7 +61,7 @@ testStream = runTest do
             result <- makeAff \cb -> do
                 unlisten <- listen b \value ->
                     cb $ Right value 
-                send 2 a
+                send a 2
                 unlisten
                 pure nonCanceler 
             Assert.equal result 4
@@ -75,8 +75,8 @@ testStream = runTest do
                     Ref.modify_ (\xs -> snoc xs value) refList
                     xs <- Ref.read refList
                     if (length xs == 2) then (cb $ Right xs) else (pure unit)
-                send 2 a
-                send 3 a
+                send a 2
+                send a 3
                 unlisten
                 pure nonCanceler 
             Assert.equal (fromFoldable [4, 6]) results
@@ -87,7 +87,7 @@ testStream = runTest do
             result <- makeAff \cb -> do
                 unlisten <- listen b \value ->
                     cb $ Right value 
-                send 2 a
+                send a 2
                 unlisten
                 pure nonCanceler 
             Assert.equal result 4
@@ -101,8 +101,8 @@ testStream = runTest do
                     cb $ Right value 
                 runTransaction (
                     do 
-                        send 2 a
-                        send 3 a
+                        send a 2
+                        send a 3
                 )
                 unlisten
                 pure nonCanceler 
@@ -115,8 +115,8 @@ testStream = runTest do
                     cb $ Right value 
                 runTransaction (
                     do 
-                        send 2 a
-                        send 3 a
+                        send a 2
+                        send a 3
                 )
                 unlisten
                 pure nonCanceler 
@@ -130,8 +130,8 @@ testStream = runTest do
                     cb $ Right value 
                 runTransaction (
                     do 
-                        send 3 a
-                        send 2 b
+                        send a 2
+                        send b 3
                 )
                 unlisten
                 pure nonCanceler 
@@ -145,8 +145,8 @@ testStream = runTest do
                     cb $ Right value 
                 runTransaction (
                     do 
-                        send 2 a
-                        send 3 b
+                        send a 2
+                        send b 3
                 )
                 unlisten
                 pure nonCanceler 
@@ -160,8 +160,8 @@ testStream = runTest do
                     cb $ Right value 
                 runTransaction (
                     do 
-                        send 2 a
-                        send 3 b
+                        send a 2
+                        send b 3
                 )
                 unlisten
                 pure nonCanceler 
@@ -173,9 +173,9 @@ testStream = runTest do
             result <- makeAff \cb -> do
                 unlisten <- listen b \value ->
                     cb $ Right value 
-                send 4 a
-                send 3 a
-                send 2 a
+                send a 4
+                send a 3
+                send a 2
                 unlisten
                 pure nonCanceler 
             Assert.equal result 2
@@ -188,10 +188,10 @@ testStream = runTest do
             result <- makeAff \cb -> do
                 unlisten <- listen c \value ->
                     cb $ Right value 
-                send 4 a
-                send 3 a
-                send true b
-                send 2 a
+                send a 4
+                send a 3
+                send b true
+                send a 2
                 unlisten
                 pure nonCanceler 
             Assert.equal result 2
@@ -204,7 +204,7 @@ testStream = runTest do
             result <- makeAff \cb -> do
                 unlisten <- listen c \value ->
                     cb $ Right value 
-                send 1 a
+                send a 1
                 unlisten
                 pure nonCanceler 
             Assert.equal result 2
@@ -215,7 +215,7 @@ testStream = runTest do
             result <- makeAff \cb -> do
                 unlisten <- listen c \value ->
                     cb $ Right value 
-                send 1 a
+                send a 1
                 unlisten
                 pure nonCanceler 
             Assert.equal result 3
@@ -229,7 +229,7 @@ testStream = runTest do
             result <- makeAff \cb -> do
                 unlisten <- listen d \value ->
                     cb $ Right value 
-                send 1 a
+                send a 1
                 unlisten
                 pure nonCanceler 
             Assert.equal result 6
@@ -244,7 +244,7 @@ testStream = runTest do
             result <- makeAff \cb -> do
                 unlisten <- listen e \value ->
                     cb $ Right value 
-                send 1 a
+                send a 1
                 unlisten
                 pure nonCanceler 
             Assert.equal result 10 
@@ -262,7 +262,7 @@ testStream = runTest do
             result <- makeAff \cb -> do
                 unlisten <- listen f \value ->
                     cb $ Right value 
-                send 1 a
+                send a 1
                 unlisten
                 pure nonCanceler 
             Assert.equal result 15 
@@ -281,7 +281,7 @@ testStream = runTest do
             result <- makeAff \cb -> do
                 unlisten <- listen g \value ->
                     cb $ Right value 
-                send 1 a
+                send a 1
                 unlisten
                 pure nonCanceler 
             Assert.equal result 21 
@@ -304,7 +304,7 @@ testStream = runTest do
             result <- makeAff \cb -> do
                 unlisten <- listen b \value ->
                     cb $ Right value 
-                send 1 a
+                send a 1
                 unlisten
                 pure nonCanceler 
             Assert.equal result 2 
@@ -318,8 +318,8 @@ testStream = runTest do
                     Ref.modify_ (\xs -> snoc xs value) refList
                     xs <- Ref.read refList
                     if (length xs == 2) then (cb $ Right xs) else (pure unit)
-                send 1 a
-                send 1 a
+                send a 1
+                send a 1
                 unlisten
                 pure nonCanceler 
             Assert.equal (fromFoldable [2, 3]) results
@@ -336,7 +336,7 @@ testStream = runTest do
                     Ref.modify_ (\xs -> snoc xs value) refList
                     xs <- Ref.read refList
                     if (length xs == 2) then (cb $ Right xs) else (pure unit)
-                send 1 a
+                send a 1
                 unlisten
                 pure nonCanceler 
 
@@ -352,8 +352,8 @@ testStream = runTest do
                     Ref.modify_ (\xs -> snoc xs value) refList
                     xs <- Ref.read refList
                     if (length xs == 3) then (cb $ Right xs) else (pure unit)
-                send 1 a
-                send 1 a
+                send a 1
+                send a 1
                 unlisten
                 pure nonCanceler 
 
@@ -365,7 +365,7 @@ testStream = runTest do
             result <- makeAff \cb -> do
                 unlisten <- listen b \value ->
                     cb $ Right value 
-                send 2 a
+                send a 2
                 unlisten
                 pure nonCanceler 
             Assert.equal result 2
@@ -376,7 +376,7 @@ testStream = runTest do
             result <- makeAff \cb -> do
                 unlisten <- listen b \value ->
                     cb $ Right value 
-                send (mockDbGet) a
+                send a (mockDbGet)
                 unlisten
                 pure nonCanceler 
             Assert.equal result "DB RESULT" 

--- a/test/Stream.test.purs
+++ b/test/Stream.test.purs
@@ -83,7 +83,7 @@ testStream = runTest do
 
         test "mapTo" do
             a <- liftEffect $ newStreamSink Nothing
-            let b = mapTo a 4
+            let b = mapTo 4 a
             result <- makeAff \cb -> do
                 unlisten <- listen b \value ->
                     cb $ Right value 

--- a/test/Stream.test.purs
+++ b/test/Stream.test.purs
@@ -135,7 +135,7 @@ testStream = runTest do
                 )
                 unlisten
                 pure nonCanceler 
-            Assert.equal 3 result
+            Assert.equal 2 result
         test "merge left" do
             a <- liftEffect $ newStreamSink Nothing 
             b <- liftEffect $ newStreamSink Nothing

--- a/test/Stream.test.purs
+++ b/test/Stream.test.purs
@@ -184,7 +184,7 @@ testStream = runTest do
         test "gate" do
             a <- liftEffect $ newStreamSink Nothing
             b <- liftEffect $ newCellSink false Nothing
-            let c = gate b a
+            let c = gate a b
             result <- makeAff \cb -> do
                 unlisten <- listen c \value ->
                     cb $ Right value 

--- a/test/Transaction.test.purs
+++ b/test/Transaction.test.purs
@@ -34,7 +34,7 @@ testTransaction = runTest do
             result <- liftEffect $ runTransaction (do
                 l <- newStreamLoop
                 let s = newStream 
-                loopStream s l
+                loopStream l s
                 pure unit 
             )
             pure unit

--- a/test/Transaction.test.purs
+++ b/test/Transaction.test.purs
@@ -25,7 +25,7 @@ testTransaction = runTest do
             result <- liftEffect $ runTransaction (do
                 l <- newCellLoop
                 let c = newCell 2
-                loopCell c l
+                loopCell l c
                 sample l 
             )
             Assert.equal result 2


### PR DESCRIPTION
After making the changes and playing with it a bit- I think this is _much_ nicer, and it fits closer to the Haskell implementation.

Note that functions are still the first argument where they occur, and for accum/collect the initial state also precedes the sodium objects (same with lambda deps)

The difference is really about ordering the sodium arguments. This also makes more sense imho since partial application would generally want to have the target object first, and then the specifics passed to it. For example, gating or snapshotting a stream makes more sense to have the stream first, then provide the target cell as an argument.

