### PR TITLE
Make it build with pulp 13.0.0, purs 0.13.4

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,10 +23,10 @@
     "tests"
   ],
   "dependencies": {
-    "purescript-aff": "^5.0.2",
-    "purescript-nullable": "^4.0.0",
-    "purescript-test-unit": "^14.0.0",
-    "purescript-quickcheck-laws": "^4.0.0",
-    "purescript-numbers": "^6.0.0"
+    "purescript-aff": "^5.1.2",
+    "purescript-nullable": "^4.1.1",
+    "purescript-test-unit": "^15.0.0",
+    "purescript-quickcheck-laws": "^5.1.0",
+    "purescript-numbers": "^7.0.0"
   }
 }


### PR DESCRIPTION
The build (master) fails for me with:

```
Error found:
in module Type.Row
at bower_components/purescript-typelevel-prelude/src/Type/Row.purs:4:5 - 4:24 (line 4, column 5 - line 4, column 24)

  Export for type Prim.RowList.Cons conflicts with type class Prim.Row.Cons


See https://github.com/purescript/documentation/blob/master/errors/ExportConflict.md for more information,
or to contribute content related to this error.
```

The patch updates the dependencies so that it builds. Tests pass.